### PR TITLE
Use billiard instead of multiprocessing

### DIFF
--- a/ptero_lsf/implementation/celery_tasks/lsf_task.py
+++ b/ptero_lsf/implementation/celery_tasks/lsf_task.py
@@ -1,5 +1,5 @@
 from .. import models
-from multiprocessing import Pipe, Process
+from billiard import Pipe, Process
 from ptero_lsf.implementation import statuses
 import celery
 import logging


### PR DESCRIPTION
http://stackoverflow.com/questions/30624290/celery-daemonic-processes-are-not-allowed-to-have-children

Celery uses the billiard library instead of the multiprocessing library
it spawn subprocesses when eventlet is not being used to manage the
subprocess pool.  The billiard library and the multiprocessing
library are not compatible.  So when eventlet is not being used,
billiard should be used to spawn subprocesses.