### PR TITLE
Update lsf requirement

### DIFF
--- a/lsf-requirements.txt
+++ b/lsf-requirements.txt
@@ -1,1 +1,1 @@
-lsf == v0.1.0
+-e git+http://github.com/genome/lsf-python.git@511d9aa#egg=lsf


### PR DESCRIPTION
This lsf update fixes a bug related to open filehandles and lsf8.  We
stop using pypi here because it seems unnecessary and inconvienent.