### PR TITLE
Explicitly set the concurrency in the Procfile for celery workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,6 @@
 web: gunicorn --bind 0.0.0.0:$PTERO_LSF_PORT ptero_lsf.api.wsgi:app --access-logfile - --error-logfile -
-poller: celery worker -A ptero_lsf.implementation.celery_app -Q poll
-updater: celery worker -A ptero_lsf.implementation.celery_app -Q update
-worker:  celery worker -A ptero_lsf.implementation.celery_app -Q lsftask
-http_worker: celery worker -A ptero_lsf.implementation.celery_app -Q http
+poller: celery worker -A ptero_lsf.implementation.celery_app -Q poll --concurrency 1
+updater: celery worker -A ptero_lsf.implementation.celery_app -Q update --concurrency 1
+worker:  celery worker -A ptero_lsf.implementation.celery_app -Q lsftask --concurrency 1
+http_worker: celery worker -A ptero_lsf.implementation.celery_app -Q http --concurrency 1
 scheduler: celery beat -A ptero_lsf.implementation.celery_app


### PR DESCRIPTION
It was previously defaulting to the number of CPUs on the host machine.