### PR TITLE
Lsf kill task

### DIFF
--- a/ptero_lsf/implementation/backend.py
+++ b/ptero_lsf/implementation/backend.py
@@ -54,9 +54,9 @@ class Backend(object):
         self.session.rollback()
 
     @property
-    def lsf(self):
+    def lsf_submit(self):
         return self.celery_app.tasks[
-'ptero_lsf.implementation.celery_tasks.lsf_task.LSFTask'
+'ptero_lsf.implementation.celery_tasks.lsf_task.LSFSubmit'
         ]
 
     def create_job(self, command, job_id, options=None, rLimits=None,
@@ -83,9 +83,9 @@ class Backend(object):
         LOG.debug("Job (%s) committed to DB", job.id,
                 extra={'jobId': job.id})
 
-        LOG.info("Submitting Celery LSFTask for job (%s)",
+        LOG.info("Submitting Celery LSFSubmit task for job (%s)",
                 job.id, extra={'jobId': job.id})
-        self.lsf.delay(job.id)
+        self.lsf_submit.delay(job.id)
 
         return job.as_dict
 

--- a/ptero_lsf/implementation/celery_app.py
+++ b/ptero_lsf/implementation/celery_app.py
@@ -12,7 +12,7 @@ app = celery.Celery('PTero-LSF-celery', include=TASK_PATH)
 
 app.conf['CELERY_ROUTES'] = (
     {
-        'ptero_lsf.implementation.celery_tasks.lsf_task.LSFTask':
+        'ptero_lsf.implementation.celery_tasks.lsf_task.LSFSubmit':
             {'queue': 'lsftask'},
         'ptero_lsf.implementation.celery_tasks.polling.PollActiveJobs':
             {'queue': 'poll'},

--- a/ptero_lsf/implementation/celery_app.py
+++ b/ptero_lsf/implementation/celery_app.py
@@ -14,6 +14,8 @@ app.conf['CELERY_ROUTES'] = (
     {
         'ptero_lsf.implementation.celery_tasks.lsf_task.LSFSubmit':
             {'queue': 'lsftask'},
+        'ptero_lsf.implementation.celery_tasks.lsf_task.LSFKill':
+            {'queue': 'lsftask'},
         'ptero_lsf.implementation.celery_tasks.polling.PollActiveJobs':
             {'queue': 'poll'},
         'ptero_lsf.implementation.celery_tasks.job_status.UpdateJobStatus':

--- a/ptero_lsf/implementation/celery_tasks/__init__.py
+++ b/ptero_lsf/implementation/celery_tasks/__init__.py
@@ -1,5 +1,5 @@
 from .job_status import UpdateJobStatus
-from .lsf_task import LSFTask
+from .lsf_task import *
 from .polling import PollActiveJobs
 from ptero_common.celery.http import *
 

--- a/ptero_lsf/implementation/celery_tasks/lsf_task.py
+++ b/ptero_lsf/implementation/celery_tasks/lsf_task.py
@@ -5,7 +5,7 @@ from ptero_common import nicer_logging
 LOG = nicer_logging.getLogger(__name__)
 
 
-__all__ = ['LSFSubmit']
+__all__ = ['LSFSubmit', 'LSFKill']
 
 
 class LSFSubmit(celery.Task):
@@ -17,5 +17,18 @@ class LSFSubmit(celery.Task):
             backend.submit_job_to_lsf(job_id)
         except:
             LOG.exception("Exception while trying to submit job (%s) to lsf",
+                    job_id, extra={'jobId': job_id})
+            raise
+
+
+class LSFKill(celery.Task):
+    def run(self, job_id):
+        LOG.info("Preparing to kill job (%s)", job_id,
+                extra={'jobId': job_id})
+        try:
+            backend = celery.current_app.factory.create_backend()
+            backend.kill_lsf_job(job_id)
+        except:
+            LOG.exception("Exception while trying to kill job (%s)",
                     job_id, extra={'jobId': job_id})
             raise

--- a/ptero_lsf/implementation/celery_tasks/lsf_task.py
+++ b/ptero_lsf/implementation/celery_tasks/lsf_task.py
@@ -5,10 +5,10 @@ from ptero_common import nicer_logging
 LOG = nicer_logging.getLogger(__name__)
 
 
-__all__ = ['LSFTask']
+__all__ = ['LSFSubmit']
 
 
-class LSFTask(celery.Task):
+class LSFSubmit(celery.Task):
     def run(self, job_id):
         LOG.info("Preparing to submit job (%s) to lsf", job_id,
                 extra={'jobId': job_id})

--- a/tests/api/v1/test_kill.py
+++ b/tests/api/v1/test_kill.py
@@ -8,13 +8,13 @@ class KillTest(BaseAPITest):
         final_cb_server = self.create_callback_server([200, 200])
 
         submit_data = {
-            'command': 'sleep 60',
+            'command': 'sleep 8675309',
             'pollingInterval': 3,
             'options': {
                 'numProcessors': 1,
             },
             'rLimits': {
-                'RSS': 10,
+                'RSS': 1000000,
             },
             'webhooks': {
                 'submitted': initial_cb_server.url,


### PR DESCRIPTION
This was needed because the web worker doesn't have access to lsf bindings.