### PR TITLE
Make Celery API change rollover for LSFTask

### DIFF
--- a/ptero_lsf/implementation/celery_app.py
+++ b/ptero_lsf/implementation/celery_app.py
@@ -12,6 +12,8 @@ app = celery.Celery('PTero-LSF-celery', include=TASK_PATH)
 
 app.conf['CELERY_ROUTES'] = (
     {
+        'ptero_lsf.implementation.celery_tasks.lsf_task.LSFTask':
+            {'queue': 'lsftask'},
         'ptero_lsf.implementation.celery_tasks.lsf_task.LSFSubmit':
             {'queue': 'lsftask'},
         'ptero_lsf.implementation.celery_tasks.lsf_task.LSFKill':

--- a/ptero_lsf/implementation/celery_tasks/lsf_task.py
+++ b/ptero_lsf/implementation/celery_tasks/lsf_task.py
@@ -5,7 +5,18 @@ from ptero_common import nicer_logging
 LOG = nicer_logging.getLogger(__name__)
 
 
-__all__ = ['LSFSubmit', 'LSFKill']
+__all__ = ['LSFTask', 'LSFSubmit', 'LSFKill']
+
+
+class LSFTask(celery.Task):
+    def run(self, job_id):
+        LOG.warning("LSFTask is deprecated, issuing LSFSubmit for job (%s)",
+                job_id, extra={'jobId': job_id})
+
+        new_task = celery.current_app.tasks[
+            'ptero_lsf.implementation.celery_tasks.lsf_task.LSFSubmit'
+        ]
+        new_task.delay(job_id)
 
 
 class LSFSubmit(celery.Task):


### PR DESCRIPTION
This allows us to safely migrate the Celery task API over the course of two deployments.