### PR TITLE
Honor 'awaiting_update' column again

### DIFF
--- a/ptero_lsf/implementation/backend.py
+++ b/ptero_lsf/implementation/backend.py
@@ -238,12 +238,13 @@ class Backend(object):
 
         job_ids_to_update = []
         for job in jobs:
-            job_ids_to_update.append(job.id)
             if job.awaiting_update:
-                LOG.warning("Awaiting update already set to True for job (%s)",
+                LOG.error("Awaiting update already set to True for job (%s)",
                         job.id, extra={'jobID': job.id})
             else:
+                job_ids_to_update.append(job.id)
                 job.awaiting_update = True
+
         self.session.commit()
 
         return job_ids_to_update


### PR DESCRIPTION
This was temporarily disabled while we were debugging.  The bug turned
out to be rogue lsf worker processes being spun up using our production
configuration on development VMs where they couldn't handle the work
they were given.  This has been protected against in deployment and now
we can turn the warning into an error.