### PR TITLE
Support lsf jobGroup option

### DIFF
--- a/lsf-requirements.txt
+++ b/lsf-requirements.txt
@@ -1,1 +1,1 @@
--e git+http://github.com/genome/lsf-python.git@c376b4b#egg=lsf
+-e git+http://github.com/genome/lsf-python.git@bfb71ae#egg=lsf

--- a/ptero_lsf/api/v1/schemas/post_job.json
+++ b/ptero_lsf/api/v1/schemas/post_job.json
@@ -60,7 +60,7 @@
             "properties": {
                 "beginTime": { "type": "integer" },
                 "errFile": { "type": "string" },
-                "group": { "type": "string" },
+                "jobGroup": { "type": "string" },
                 "inFile": { "type": "string" },
                 "jobName": { "type": "string" },
                 "mail_user": { "type": "string" },


### PR DESCRIPTION
Fixes #80

There was support for an option named "group" which was not a valid lsf
option.  Support for "group" has been replaced by "jobGroup".