### PR TITLE
Bugfix: eliminate race condition with submission

### DIFF
--- a/ptero_lsf/implementation/backend.py
+++ b/ptero_lsf/implementation/backend.py
@@ -126,6 +126,7 @@ class Backend(object):
 
             job.lsf_job_id = lsf_job_id
             job.set_status(statuses.submitted)
+            job.update_poll_after()
 
         except Exception as e:
             job.set_status(statuses.errored, message=e.message)
@@ -232,6 +233,7 @@ class Backend(object):
                     pformat(job_data['statuses']),
                     extra={'jobId': job_id, 'lsfJobId': service_job.lsf_job_id})
             service_job.update_status(job_data['statuses'])
+            service_job.update_poll_after()
 
         self.session.commit()
         return True

--- a/ptero_lsf/implementation/models/job.py
+++ b/ptero_lsf/implementation/models/job.py
@@ -66,7 +66,6 @@ class Job(Base):
 
     def set_status(self, status, message=None):
         JobStatusHistory(job=self, status=status, message=message)
-        self.update_poll_after()
         self.trigger_webhook(status)
 
     def update_status(self, lsf_status_set, message=None):
@@ -87,8 +86,6 @@ class Job(Base):
                              lsf_primary_status=lsf_primary_status,
                              message=message)
             self.trigger_webhook(current_status)
-
-        self.update_poll_after()
 
     def update_poll_after(self):
         if self.latest_status.status in _TERMINAL_STATUSES:

--- a/ptero_lsf/implementation/models/job.py
+++ b/ptero_lsf/implementation/models/job.py
@@ -191,7 +191,9 @@ class Job(Base):
 
     def trigger_webhook(self, webhook_name):
         if webhook_name:
-            urls = self.webhooks.get(webhook_name, [])
+            webhooks = self.webhooks if self.webhooks is not None else {}
+
+            urls = webhooks.get(webhook_name, [])
             if not isinstance(urls, list):
                 urls = [urls]
 


### PR DESCRIPTION
Fixes #107 

Previously, the poll_after field was updated every time a status was
set, including the 'new' status at job creation time.  This mean that
the job status updating celery task and the job submission celery task
were racing each other.  If the status updating won the race, the job
will not yet have a lsf_job_id and errors would occur.

Now, the poll_after field is only updated once when the 'submitted'
status is reached, and during the status updating celery task.