### PR TITLE
Allow stdout and stderr to be patched to job

### DIFF
--- a/ptero_lsf/alembic/versions/f0d37ce6c095_add_stdio_to_job.py
+++ b/ptero_lsf/alembic/versions/f0d37ce6c095_add_stdio_to_job.py
@@ -1,0 +1,25 @@
+"""Add stdio to job
+
+Revision ID: f0d37ce6c095
+Revises: 53dec4636bce
+Create Date: 2016-01-29 20:35:43.118787
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'f0d37ce6c095'
+down_revision = '53dec4636bce'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('job', sa.Column('stderr', sa.Text(), nullable=True))
+    op.add_column('job', sa.Column('stdout', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('job', 'stdout')
+    op.drop_column('job', 'stderr')

--- a/ptero_lsf/api/v1/views.py
+++ b/ptero_lsf/api/v1/views.py
@@ -44,7 +44,7 @@ class JobView(Resource):
 
         data = request.json
         patch_keys = set(data.keys())
-        allowed_keys = set(['status'])
+        allowed_keys = set(['status', 'stdout', 'stderr'])
 
         disallowed_keys = patch_keys - allowed_keys
         if disallowed_keys:

--- a/ptero_lsf/implementation/backend.py
+++ b/ptero_lsf/implementation/backend.py
@@ -275,11 +275,17 @@ class Backend(object):
         return job.as_dict
 
     def update_job_status(self, job, status):
-        if status == statuses.canceled:
-            self.cancel_job(job.id, message="Job canceled via PATCH request")
+        if isinstance(status, basestring):
+            message = "Updated via PATCH request"
         else:
-            if status is not None:
-                job.set_status(status, message="Updated via PATCH request")
+            # status is a two element list [<status>, <message>]
+            message = status[-1]
+            status = status[0]
+
+        if status == statuses.canceled:
+            self.cancel_job(job.id, message=message)
+        else:
+            job.set_status(status, message=message)
 
     def update_job_stdout(self, job, stdout):
         job.stdout = stdout

--- a/ptero_lsf/implementation/backend.py
+++ b/ptero_lsf/implementation/backend.py
@@ -75,6 +75,10 @@ class Backend(object):
         if umask is not None:
             umask = int(umask, 8)
 
+        if environment is None:
+            environment = {}
+        environment.update(_LSF_ENVIRONMENT_VARIABLES)
+
         job = models.Job(id=job_id, command=command, options=options,
                 rlimits=rLimits, webhooks=webhooks,
                 polling_interval=polling_interval, cwd=cwd,
@@ -170,7 +174,6 @@ class Backend(object):
             job.set_user_and_groups()
 
             job.set_environment()
-            os.environ.update(_LSF_ENVIRONMENT_VARIABLES)
 
             job.set_cwd()
             job.set_umask()

--- a/ptero_lsf/implementation/backend.py
+++ b/ptero_lsf/implementation/backend.py
@@ -5,7 +5,6 @@ from pprint import pformat
 from ptero_common import nicer_logging
 from ptero_common.server_info import get_server_info
 from ptero_lsf.exceptions import JobNotFoundError
-from exceptions import RuntimeError
 from ptero_lsf.implementation import statuses
 from sqlalchemy import func
 import datetime
@@ -269,7 +268,7 @@ class Backend(object):
             if value is not None:
                 LOG.debug('Updating %s for job (%s) to [%s]', key, job.id,
                         value)
-                update_fn = getattr("update_job_%s" % key, self)
+                update_fn = getattr(self, "update_job_%s" % key)
                 update_fn(job, value)
 
         self.session.commit()
@@ -283,16 +282,10 @@ class Backend(object):
                 job.set_status(status, message="Updated via PATCH request")
 
     def update_job_stdout(self, job, stdout):
-        if job.stdout is None:
-            job.stdout = stdout
-        elif job.stdout != stdout:
-            raise RuntimeError
+        job.stdout = stdout
 
     def update_job_stderr(self, job, stderr):
-        if job.stderr is None:
-            job.stderr = stderr
-        elif job.stderr != stderr:
-            raise RuntimeError
+        job.stderr = stderr
 
     def cancel_job(self, job_id, message):
         job = self._get_job(job_id)

--- a/ptero_lsf/implementation/backend.py
+++ b/ptero_lsf/implementation/backend.py
@@ -38,6 +38,9 @@ def _collect_lsf_environment():
 
 
 _LSF_ENVIRONMENT_VARIABLES = _collect_lsf_environment()
+_JOB_URL_BASE = "http://%s:%s/v1/jobs/" % (
+        os.environ['PTERO_LSF_HOST'],
+        os.environ['PTERO_LSF_PORT'])
 
 
 class SubmitError(Exception):
@@ -78,6 +81,7 @@ class Backend(object):
         if environment is None:
             environment = {}
         environment.update(_LSF_ENVIRONMENT_VARIABLES)
+        environment['PTERO_LSF_JOB_URL'] = _JOB_URL_BASE + job_id
 
         job = models.Job(id=job_id, command=command, options=options,
                 rlimits=rLimits, webhooks=webhooks,

--- a/ptero_lsf/implementation/backend.py
+++ b/ptero_lsf/implementation/backend.py
@@ -262,20 +262,15 @@ class Backend(object):
         result['databaseRevision'] = self.db_revision
         return result
 
-    def update_job(self, job_id, status=None, stdout=None, stderr=None):
+    def update_job(self, job_id, **kwargs):
         job = self._get_job(job_id)
 
-        if status is not None:
-            LOG.debug('Updating status for job (%s) to [%s]', job.id, status)
-            self.update_job_status(job, status)
-
-        if stdout is not None:
-            LOG.debug('Updating stdout for job (%s) to [%s]', job.id, stdout)
-            self.update_job_stdout(job, stdout)
-
-        if stderr is not None:
-            LOG.debug('Updating stderr for job (%s) to [%s]', job.id, stderr)
-            self.update_job_stderr(job, stderr)
+        for key, value in kwargs.items():
+            if value is not None:
+                LOG.debug('Updating %s for job (%s) to [%s]', key, job.id,
+                        value)
+                update_fn = getattr("update_job_%s" % key, self)
+                update_fn(job, value)
 
         self.session.commit()
         return job.as_dict

--- a/ptero_lsf/implementation/celery_tasks/job_status.py
+++ b/ptero_lsf/implementation/celery_tasks/job_status.py
@@ -16,7 +16,7 @@ class UpdateJobStatus(celery.Task):
                 extra={'jobId': job_id})
         try:
             backend = celery.current_app.factory.create_backend()
-            backend.update_job_status(job_id)
+            backend.update_job_with_lsf_status(job_id)
         except:
             LOG.exception(
                 "Exception while trying to update status for job (%s)",

--- a/ptero_lsf/implementation/models/job.py
+++ b/ptero_lsf/implementation/models/job.py
@@ -38,6 +38,9 @@ class Job(Base):
     options = Column(JSON)
     rlimits = Column(JSON)
 
+    stdout = Column(Text)
+    stderr = Column(Text)
+
     cwd = Column(Text, nullable=False)
     environment = Column(JSON, default=dict)
     umask = Column(Integer)
@@ -173,6 +176,8 @@ class Job(Base):
             'statusHistory': [h.as_dict for h in self.status_history],
             'user': self.user,
             'webhooks': self.webhooks,
+            'stdout': self.stdout,
+            'stderr': self.stderr,
         }
 
         if self.poll_after is not None:
@@ -184,6 +189,8 @@ class Job(Base):
         self._conditional_add(result, 'options', 'options')
         self._conditional_add(result, 'rlimits', 'rLimits')
         self._conditional_add(result, 'lsf_job_id', 'lsfJobId')
+#        self._conditional_add(result, 'stdout', 'stdout')
+#        self._conditional_add(result, 'stderr', 'stderr')
 
         return result
 

--- a/tests/api/v1/test_patch.py
+++ b/tests/api/v1/test_patch.py
@@ -1,0 +1,46 @@
+from .base import BaseAPITest
+import pprint
+
+
+class PatchTest(BaseAPITest):
+    def test_patching(self):
+        cb_server = self.create_callback_server([200])
+
+        submit_data = {
+            'command': 'true',
+            'pollingInterval': 3,
+            'webhooks': {
+                'succeeded': cb_server.url,
+            },
+        }
+        self.update_submit_data(submit_data)
+
+        response = self.post(self.jobs_url, submit_data)
+        job_url = response.headers['Location']
+        self.print_response(response)
+
+        webhook_data = cb_server.stop()
+        pprint.pprint(webhook_data)
+
+        # patch with custom message
+        patch_response = self.patch(job_url,
+                {'status': ['failed', 'Some custom message']})
+        self.assertEqual(patch_response.status_code, 200)
+
+        get_response = self.get(job_url)
+        self.assertEqual('Some custom message',
+                get_response.DATA['statusHistory'][-1]['message'])
+
+        # patch status without custom message
+        patch_response = self.patch(job_url,
+                {'status': 'errored'})
+        self.assertEqual(patch_response.status_code, 200)
+
+        get_response = self.get(job_url)
+        self.assertEqual('Updated via PATCH request',
+                get_response.DATA['statusHistory'][-1]['message'])
+
+        # patch unsported field
+        patch_response = self.patch(job_url,
+                {'foo': 'bar'})
+        self.assertEqual(patch_response.status_code, 400)

--- a/tests/api/v1/test_set_stdio.py
+++ b/tests/api/v1/test_set_stdio.py
@@ -1,0 +1,55 @@
+from .base import BaseAPITest
+import pprint
+
+
+class SetStdioTest(BaseAPITest):
+    def test_patching_stdio(self):
+        cb_server = self.create_callback_server([200])
+
+        submit_data = {
+            'command': 'true',
+            'pollingInterval': 1,
+            'options': {
+                'numProcessors': 1,
+            },
+            'webhooks': {
+                'succeeded': cb_server.url,
+            },
+        }
+        self.update_submit_data(submit_data)
+
+        response = self.post(self.jobs_url, submit_data)
+        job_url = response.headers['Location']
+        self.print_response(response)
+
+        self.assertIn('jobId', response.DATA)
+        self.assertEqual(response.status_code, 201)
+
+        webhook_data = cb_server.stop()
+        pprint.pprint(webhook_data)
+
+        test_stdout = 'Test output message here.'
+        test_stderr = 'Test error message here.'
+
+        response = self.patch(job_url, {
+            'stdout': test_stdout,
+            'stderr': test_stderr})
+        self.assertEqual(response.status_code, 200)
+
+        response = self.get(job_url)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertIn('stdout', response.DATA)
+        self.assertEqual(test_stdout, response.DATA['stdout'])
+
+        self.assertIn('stderr', response.DATA)
+        self.assertEqual(test_stderr, response.DATA['stderr'])
+
+        response = self.patch(job_url, {
+            'stdout': test_stdout,
+            'stderr': test_stderr})
+        self.assertEqual(response.status_code, 200)
+
+        response = self.patch(job_url, {
+            'stdout': 'A different message'})
+        self.assertEqual(response.status_code, 400)

--- a/tests/api/v1/test_submit.py
+++ b/tests/api/v1/test_submit.py
@@ -195,3 +195,31 @@ class SubmitTest(BaseAPITest):
 
         self.assertIsInstance(status_response.DATA['lsfJobId'], int)
         self.assertEqual('succeeded', status_response.DATA['status'])
+
+    def test_posted_job_gets_url_in_env(self):
+        submit_data = {
+            'command': 'true',
+            'pollingInterval': 1,
+        }
+        self.update_submit_data(submit_data)
+
+        response = self.post(self.jobs_url, submit_data)
+        self.print_response(response)
+
+        self.assertIn('jobId', response.DATA)
+        self.assertEqual(response.status_code, 201)
+
+        job_url = response.headers['Location']
+        get_response = self.get(job_url)
+        self.assertEqual(get_response.status_code, 200)
+        self.print_response(get_response)
+
+        self.assertIn('PTERO_LSF_JOB_URL', get_response.DATA['environment'])
+
+        second_get_response = self.get(
+                get_response.DATA['environment']['PTERO_LSF_JOB_URL'])
+        self.assertEqual(second_get_response.status_code, 200)
+        self.print_response(second_get_response)
+
+        self.assertEqual(get_response.DATA['jobId'],
+                second_get_response.DATA['jobId'])

--- a/tests/implementation/test_backend.py
+++ b/tests/implementation/test_backend.py
@@ -24,14 +24,14 @@ class TestBackend(unittest.TestCase):
         self.backend.create_job('false', job_id, user='nobody')
         job = self.session.query(models.Job).get(job_id)
         job.lsf_job_id = 82
-        self.assertFalse(self.backend.update_job_status(job_id))
+        self.assertFalse(self.backend.update_job_with_lsf_status(job_id))
 
     def test_update_job_without_lsf_id(self):
         job_id = str(uuid.uuid4())
         self.backend.create_job('false', job_id, user='nobody')
         job = self.session.query(models.Job).get(job_id)
         job.lsf_job_id = None
-        self.assertFalse(self.backend.update_job_status(job_id))
+        self.assertFalse(self.backend.update_job_with_lsf_status(job_id))
 
     def test_create_and_cancel_job(self):
         job_id = str(uuid.uuid4())
@@ -46,7 +46,7 @@ class TestBackend(unittest.TestCase):
         self.assertTrue(self.backend.job_is_canceled(job_id))
 
         for i in range(20):
-            if self.backend.update_job_status(job_id):
+            if self.backend.update_job_with_lsf_status(job_id):
                 print "job %s has dispatched to lsf" % job_id
                 break
             else:


### PR DESCRIPTION
Closes #104 

I consider this PR a WIP.  Tests are passing but I would like to clean up a few things before merging:
* replace RuntimeError with a more specific exception
* possibly break this into a couple commits
* make job dict conditionally contain stdout and stderr (currently unconditional)

Feel free to comment though if you see something you would like to have changed.