### PR TITLE
Don't get back the execution info for LSF jobs when querying status.

### DIFF
--- a/lsf-requirements.txt
+++ b/lsf-requirements.txt
@@ -1,1 +1,1 @@
--e git+http://github.com/genome/lsf-python.git@bfb71ae#egg=lsf
+-e git+http://github.com/genome/lsf-python.git@c1ec25a#egg=lsf

--- a/ptero_lsf/implementation/backend.py
+++ b/ptero_lsf/implementation/backend.py
@@ -216,7 +216,7 @@ class Backend(object):
             LOG.info("Querying LSF about job (%s) with lsf id [%s]",
                     job_id, service_job.lsf_job_id,
                     extra={'jobId': job_id, 'lsfJobId': service_job.lsf_job_id})
-            lsf_job = lsf.get_job(service_job.lsf_job_id)
+            lsf_job = lsf.get_job(service_job.lsf_job_id, include_exec_info=False)
 
             try:
                 job_data = lsf_job.as_dict


### PR DESCRIPTION
This uses genome/lsf-python#4 to avoid examining the execution info for a job when we really only care about its status.  The value of exHosts was causing segfaults when the LSF job requested 3 CPUs.