### PR TITLE
Reduce the priority of log messages about querying LSF job status.

### DIFF
--- a/ptero_lsf/implementation/backend.py
+++ b/ptero_lsf/implementation/backend.py
@@ -213,7 +213,7 @@ class Backend(object):
             return False
 
         else:
-            LOG.info("Querying LSF about job (%s) with lsf id [%s]",
+            LOG.debug("Querying LSF about job (%s) with lsf id [%s]",
                     job_id, service_job.lsf_job_id,
                     extra={'jobId': job_id, 'lsfJobId': service_job.lsf_job_id})
             lsf_job = lsf.get_job(service_job.lsf_job_id, include_exec_info=False)

--- a/ptero_lsf/implementation/celery_tasks/job_status.py
+++ b/ptero_lsf/implementation/celery_tasks/job_status.py
@@ -12,7 +12,7 @@ class UpdateJobStatus(celery.Task):
     ignore_result = True
 
     def run(self, job_id):
-        LOG.info('Updating job status for job (%s)', job_id,
+        LOG.debug('Updating job status for job (%s)', job_id,
                 extra={'jobId': job_id})
         try:
             backend = celery.current_app.factory.create_backend()


### PR DESCRIPTION
These happen all the time... after this change we'll still get an INFO message with the update or an error if it fails... but in 1/3 as many log messages :smile: