### PR TITLE
Allow substituting the Job ID in the output and error paths.

### DIFF
--- a/ptero_lsf/implementation/backend.py
+++ b/ptero_lsf/implementation/backend.py
@@ -87,6 +87,7 @@ class Backend(object):
                 rlimits=rLimits, webhooks=webhooks,
                 polling_interval=polling_interval, cwd=cwd,
                 environment=environment, umask=umask, user=user)
+        job.translate_output_paths()
         self.session.add(job)
 
         LOG.debug("Setting status of job (%s) to 'new'", job.id,

--- a/ptero_lsf/implementation/models/job.py
+++ b/ptero_lsf/implementation/models/job.py
@@ -11,6 +11,7 @@ from sqlalchemy.dialects.postgresql import JSON
 import celery
 import os
 import pwd
+import string
 from ptero_common import nicer_logging
 
 
@@ -121,6 +122,15 @@ class Job(Base):
     def set_umask(self):
         if self.umask is not None:
             os.umask(self.umask)
+
+    def translate_output_paths(self):
+        if self.stdout is not None:
+            self.stdout = self._translate(self.stdout)
+        if self.stderr is not None:
+            self.stderr = self._translate(self.stderr)
+
+    def _translate(self, path):
+        return string.replace(path, '%%JOB_ID%%', self.id)
 
     @property
     def process_user(self):


### PR DESCRIPTION
This addresses the parallel_by issue pointed out in genome/genome#1449.